### PR TITLE
Fix TrajectoryFollow so it ends properly

### DIFF
--- a/src/main/java/frc/robot/Autonomous/LimelightTest.java
+++ b/src/main/java/frc/robot/Autonomous/LimelightTest.java
@@ -10,6 +10,7 @@ import frc.robot.subsystems.Drive.DriveSubsystem;
 import frc.robot.subsystems.Drive.LimelightAim;
 import frc.robot.subsystems.Drive.PathResetOdometry;
 import frc.robot.subsystems.Drive.TrajectoryFollow;
+import frc.robot.subsystems.Drive.TrajectoryFollow2;
 import frc.robot.subsystems.Intake.IntakeSubsystem;
 import frc.robot.subsystems.Tower.TowerSubsystem;
 
@@ -31,8 +32,9 @@ public class LimelightTest extends SequentialCommandGroup {
     m_tower = tower;
     addCommands(
       new PathResetOdometry("4BallPart1", m_drive),
-      new TrajectoryFollow("4BallPart1", m_drive),
-      new LimelightAim(m_drive, m_limelight)
+      new TrajectoryFollow2("4BallPart1", m_drive).get(),
+      new LimelightAim(m_drive, m_limelight),
+      new TrajectoryFollow2("4BallPart2", m_drive).get()
     );
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -75,9 +75,9 @@ public class RobotContainer {
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {  
     
-    CommandScheduler.getInstance().onCommandInitialize(command -> System.out.println("CommandInitialized" + command.getName()));
-    CommandScheduler.getInstance().onCommandInterrupt(command -> System.out.println("CommandInitialized" + command.getName()));
-    CommandScheduler.getInstance().onCommandFinish(command -> System.out.println("CommandInitialized" + command.getName()));
+    // CommandScheduler.getInstance().onCommandInitialize(command -> System.out.println("CommandInitialized" + command.getName()));
+    // CommandScheduler.getInstance().onCommandInterrupt(command -> System.out.println("CommandInitialized" + command.getName()));
+    // CommandScheduler.getInstance().onCommandFinish(command -> System.out.println("CommandInitialized" + command.getName()));
 
     new Pneumactics();
   
@@ -86,7 +86,7 @@ public class RobotContainer {
     
 
     // Comment out for simulation
-    // CameraServer.startAutomaticCapture("MS Lifecam Camera", 0);
+    CameraServer.startAutomaticCapture("MS Lifecam Camera", 0);
 
 
     m_chooser.addOption("Simple Two Ball Auto", new SimpleTwoBallAuto(m_driveSubsystem, m_shooterSubystem, m_towerSubsystem, m_intakeSubsystem));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -75,9 +75,9 @@ public class RobotContainer {
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {  
     
-    CommandScheduler.getInstance().onCommandInitialize(command -> Shuffleboard.addEventMarker("CommandInitialized", command.getName(), EventImportance.kNormal));
-    CommandScheduler.getInstance().onCommandInterrupt(command -> Shuffleboard.addEventMarker("CommandInitialized", command.getName(), EventImportance.kNormal));
-    CommandScheduler.getInstance().onCommandFinish(command -> Shuffleboard.addEventMarker("CommandInitialized", command.getName(), EventImportance.kNormal));
+    CommandScheduler.getInstance().onCommandInitialize(command -> System.out.println("CommandInitialized" + command.getName()));
+    CommandScheduler.getInstance().onCommandInterrupt(command -> System.out.println("CommandInitialized" + command.getName()));
+    CommandScheduler.getInstance().onCommandFinish(command -> System.out.println("CommandInitialized" + command.getName()));
 
     new Pneumactics();
   
@@ -85,7 +85,8 @@ public class RobotContainer {
     DriverStation.silenceJoystickConnectionWarning(DriveConstants.PRACTICE);
     
 
-    CameraServer.startAutomaticCapture("MS Lifecam Camera", 0);
+    // Comment out for simulation
+    // CameraServer.startAutomaticCapture("MS Lifecam Camera", 0);
 
 
     m_chooser.addOption("Simple Two Ball Auto", new SimpleTwoBallAuto(m_driveSubsystem, m_shooterSubystem, m_towerSubsystem, m_intakeSubsystem));

--- a/src/main/java/frc/robot/subsystems/Drive/TrajectoryFollow2.java
+++ b/src/main/java/frc/robot/subsystems/Drive/TrajectoryFollow2.java
@@ -1,0 +1,63 @@
+package frc.robot.subsystems.Drive;
+import com.pathplanner.lib.PathPlanner;
+import com.pathplanner.lib.PathPlannerTrajectory;
+import com.pathplanner.lib.commands.PPSwerveControllerCommand;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.trajectory.Trajectory;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+
+public class TrajectoryFollow2 {
+
+    private String m_pathName;
+    private PathPlannerTrajectory m_trajectory = null;
+    DriveSubsystem m_drive;
+    /**
+     * Executes a trajectory that makes it remain still
+     */
+    public TrajectoryFollow2() {
+        m_pathName = "Stay Still";
+    }
+
+    public TrajectoryFollow2(String pathName, DriveSubsystem drive) {
+        m_pathName = pathName;
+        m_drive = drive;
+    }
+
+    public TrajectoryFollow2(Trajectory traj, DriveSubsystem drive) {
+        m_trajectory = (PathPlannerTrajectory) traj;
+        m_drive = drive;
+    }
+
+    public SequentialCommandGroup get() {
+        System.out.println("Trajectory begun");
+
+        if (m_trajectory == null) {
+            try {
+                m_trajectory = PathPlanner.loadPath(m_pathName, 3, 4); 
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        m_drive.m_field.getObject("traj").setTrajectory(m_trajectory);
+
+        ProfiledPIDController thetaController = new ProfiledPIDController(1, 0, 0,
+                new TrapezoidProfile.Constraints(DriveSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND,
+                        Math.pow(DriveSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND, 2)));
+        thetaController.enableContinuousInput(-Math.PI, Math.PI);
+
+        return new PPSwerveControllerCommand(m_trajectory,
+                m_drive::getCurrentPose,
+                m_drive.getKinematics(),
+                new PIDController(10, 0, 0),
+                new PIDController(10, 0, 0),
+                thetaController,
+                m_drive::actuateModulesAuto,
+                m_drive)
+                        .andThen(() -> m_drive.drive(new ChassisSpeeds(0.0, 0.0, 0.0)));
+    }
+
+}


### PR DESCRIPTION
Created the new class `TrajectoryFollow2.java` which we can use in autos where we want to use Limelight. Eventually we can switch everything to this. It also shouldn't require us to use `withTimeout` anymore which is a huge time saver. 

Note that now since TrajectoryFollow2 is just a class, to get the returning CommandGroup you have to call `.get()` on it. See `LimelightTest.java` for an example

Tested and verified in my simulator. 