### PR TITLE
LimelightAim improvements & bugfixes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -99,16 +99,16 @@ public final class Constants {
         public static final double BACK_LEFT_MODULE_STEER_OFFSET = -Math.toRadians(111.4); 
         public static final double BACK_RIGHT_MODULE_STEER_OFFSET = -Math.toRadians(133.1);
 
-        // Limelight auto aim X-axis target tolerance. This is the number of degrees
-        // from perfect center that the robot will consider the BasicLimelightAim
-        // command "finished".
-        public static final double LIMELIGHT_X_TOLERANCE = 1.0;
+        // // Limelight auto aim X-axis target tolerance. This is the number of degrees
+        // // from perfect center that the robot will consider the BasicLimelightAim
+        // // command "finished".
+        // public static final double LIMELIGHT_X_TOLERANCE = 1.0;
 
-        // Maximum Limelight auto-aim rotation velocity in radians per second.
-        public static final double LIMELIGHT_X_VELOCITY_LIMIT = 0.5;
+        // // Maximum Limelight auto-aim rotation velocity in radians per second.
+        // public static final double LIMELIGHT_X_VELOCITY_LIMIT = 0.5;
 
-        // Limelight auto-aim X-axis P-gain.
-        public static final double LIMELIGHT_X_P = 10.0;
+        // // Limelight auto-aim X-axis P-gain.
+        // public static final double LIMELIGHT_X_P = 10.0;
 
             
         public static final double precisionSpeed = 0.25;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -160,12 +160,12 @@ public class RobotContainer {
     new XBoxControllerButton(m_driverController, XBoxControllerEE.Button.kBack)
         .whenPressed(m_driveSubsystem::zeroGyroscope);
 
-    // Auto Aim Limelight\
+    // Auto Aim Limelight without ranging, with ranging, and with auto-shoot
     new XBoxControllerButton(m_driverController, XBoxControllerEE.Button.kB)
-      .whileHeld(new BasicLimelightAim(m_driveSubsystem, m_limelight));
+      .whileHeld(new LimelightAim(m_driveSubsystem, m_limelight, true, false));
 
     new XBoxControllerButton(m_driverController, XBoxControllerEE.Button.kA)
-      .whileHeld(new LimelightAim(m_driveSubsystem, m_limelight));
+      .whileHeld(new LimelightAim(m_driveSubsystem, m_limelight, true, true));
 
     new XBoxControllerButton(m_driverController, XBoxControllerEE.Button.kX)
       .whileHeld(new LimelightAutoShootTarmac(m_driveSubsystem, m_shooterSubystem, m_towerSubsystem, m_limelight));

--- a/src/main/java/frc/robot/subsystems/Drive/LimelightAim.java
+++ b/src/main/java/frc/robot/subsystems/Drive/LimelightAim.java
@@ -71,8 +71,13 @@ public class LimelightAim extends CommandBase {
 	  deltaY = ty.getDouble(0.0) - deltaYTargetTarmac; 
 	
 	  errorX = Math.abs(deltaX);
-	  errorY = Math.abs(deltaY);
-
+	  
+    if(m_ranging == true) {
+      errorY = Math.abs(deltaY);
+    }
+    else {
+      errorY = 0.0;
+    }
     //fixed clamp logic here
     //increased limits to 1.5 now that we are slowing down approaching target
     //feel free to lower these, or divide by a bigger number if oscillations occur

--- a/src/main/java/frc/robot/subsystems/Drive/LimelightAim.java
+++ b/src/main/java/frc/robot/subsystems/Drive/LimelightAim.java
@@ -9,22 +9,33 @@ public class LimelightAim extends CommandBase {
   // Initialize Variables
   DriveSubsystem m_drive;
   double m_rotation, m_translationY, m_targetThreshold, deltaX, deltaY, deltaYTargetTarmac, errorX, errorY, count; 
-  boolean m_end;
-  NetworkTableEntry tx, ty, ta;
+  boolean m_end, m_waitForTarget, m_hasTarget, m_ranging;
+  NetworkTableEntry tx, ty, ta, tv;
   NetworkTable table;
   Limelight m_limelight;
 
 
-  // Constructor for BasicLimelightAim
+  // Legacy constructor for BasicLimelightAim
+  @Deprecated
   public LimelightAim(DriveSubsystem drive, Limelight limelight) {
     m_limelight = limelight;
     m_drive = drive;
+    m_waitForTarget = false;
+    m_ranging = true;
+    addRequirements(m_drive, m_limelight);
+  }
+
+  public LimelightAim(DriveSubsystem drive, Limelight limelight, boolean waitForTarget, boolean ranging){
+    m_limelight = limelight;
+    m_drive = drive;
+    m_waitForTarget = waitForTarget;
+    m_ranging = ranging;
     addRequirements(m_drive, m_limelight);
   }
 
   @Override
   public void initialize() {
-    System.out.println("start BasicLimelightAim");
+    System.out.println("start LimelightAim");
 
     // Initialize parent NetworkTable
     table = NetworkTableInstance.getDefault().getTable("limelight");
@@ -37,7 +48,7 @@ public class LimelightAim extends CommandBase {
 
     tx = table.getEntry("tx");
     ty = table.getEntry("ty");
-    ta = table.getEntry("ta");
+    tv = table.getEntry("tv");
     count = 0;
 
     deltaYTargetTarmac = 0;
@@ -49,31 +60,37 @@ public class LimelightAim extends CommandBase {
 
     tx = table.getEntry("tx");
     ty = table.getEntry("ty");
+    tv = table.getEntry("tv");
+    m_hasTarget = tv.getDouble(0.0) == 1.0;
 	  //removed ta since it's unused and slows the loop
 	
     // get current X-axis target delta from center of image, in degrees.
     deltaX = tx.getDouble(0.0);
 	
-	// get current Y-axis target delta from center of image, with the offset in account, in degrees.
+  	// get current Y-axis target delta from center of image, with the offset in account, in degrees.
 	  deltaY = ty.getDouble(0.0) - deltaYTargetTarmac; 
 	
 	  errorX = Math.abs(deltaX);
 	  errorY = Math.abs(deltaY);
 
-  //fixed clamp logic here
-	//increased limits to 1.5 now that we are slowing down approaching target
-	//feel free to lower these, or divide by a bigger number if oscillations occur
+    //fixed clamp logic here
+    //increased limits to 1.5 now that we are slowing down approaching target
+    //feel free to lower these, or divide by a bigger number if oscillations occur
     m_rotation = Math.max(-1.5, Math.min(1.5, deltaX/6.0));
 
-	//invert the driving direction with -deltaY, since: 
-	//target at top of frame = deltaY positive = drive back (negative)
+	  //invert the driving direction with -deltaY, since: 
+  	//target at top of frame = deltaY positive = drive back (negative)
 	  m_translationY = Math.max(-1.5, Math.min(1.5, (-deltaY)/4.0)); 
 
-    m_drive.drive(new ChassisSpeeds(-m_translationY, 0, -m_rotation));
+    if(m_ranging){
+      m_drive.drive(new ChassisSpeeds(-m_translationY, 0, -m_rotation));
+    } else {
+      m_drive.drive(new ChassisSpeeds(0, 0, -m_rotation));
+    }
 	
     //tightened tolerances to +/- 1 degree now that we are 
     //slowing down as the robot is approaching the target
-    if(errorX < 0.5 && errorY < 1.0){
+    if((errorX < 0.5 && errorY < 1.0) && (!m_waitForTarget || m_hasTarget)){
       System.out.println("End command");
       m_end = true;
 
@@ -87,14 +104,15 @@ public class LimelightAim extends CommandBase {
 
     m_drive.drive(new ChassisSpeeds(0, 0, 0));
 
-    System.out.println("end BasicLimelightAim");
+    System.out.println("end LimelightAim");
     Limelight.setDriverMode();
   }
 
   @Override
   public boolean isFinished() {
     count++;
-    if(count > 50){
+    //if command finishing behavior is inconsistent, remove "|| m_hasTarget"
+    if(count > 50 || m_hasTarget){ 
       return m_end;
     }
     else{

--- a/src/main/java/frc/robot/subsystems/Shooter/LimelightAutoShootTarmac.java
+++ b/src/main/java/frc/robot/subsystems/Shooter/LimelightAutoShootTarmac.java
@@ -27,7 +27,7 @@ public class LimelightAutoShootTarmac extends SequentialCommandGroup {
         new ParallelRaceGroup(
             new ShootTarmac(m_shooter, m_tower),
             new SequentialCommandGroup(
-                new LimelightAim(m_drive, m_limelight),
+                new LimelightAim(m_drive, m_limelight, true, true),
                 new DriveTower(m_tower, (() -> TowerConstants.standardTowerSpeed * 0.8)).withTimeout(1.5) //slower to gate balls
             )
         )


### PR DESCRIPTION
Several minor functional updates included to LimelightAim & its usages to address some minor bugs and make our targeting faster 🏎

1. add `waitForTarget` constructor parameter & logic - this prevents the command from finishing if `tv == 0` (when limelight detects no targets, `tv == 0`). In autonomous modes and by default, `waitForTarget = false` since we still want to shoot when limelight may be disconnected/broken
2. add `ranging` constructor parameter & logic - this allows us to use `LimelightAim` instead of `BasicLimelightAim` for x-axis only targeting (i.e. on the launchpad). when `ranging == false`, the command will only rotate the robot, and finish when the target is centered horizontally
3. remove unused constants in RobotContainer
4. update `LimelightAutoShootTarmac` to use the new constructor, which will require a target present & aligned before shooting
5. add a bypass to the `count > 50` ending requirement, such that if we have a target, we can skip the 1000ms wait and finish the command